### PR TITLE
Combine deployment into a single project `fastly-content-fanout` in riff-raff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,27 +51,13 @@ jobs:
           FASTLY_FANOUT_SERVICE_ID_CODE: ${{ secrets.FASTLY_FANOUT_SERVICE_ID_CODE }}
           FASTLY_FANOUT_SERVICE_ID_PROD: ${{ secrets.FASTLY_FANOUT_SERVICE_ID_PROD }}
 
-      - name: Upload C@E to riff-raff
+      - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v2
         with:
-          app: fastly-content-fanout
-          config: |
-            stacks:
-              - mobile
-            regions:
-              - eu-west-1
-            deployments:
-              fastly-content-fanout:
-                  type: fastly-compute
-          contentDirectories: |
-            fastly-content-fanout:
-              - pkg/fastly-compute-fanout.tar.gz
-
-      - name: Upload eventbridge to riff-raff
-        uses: guardian/actions-riff-raff@v2
-        with:
-          projectName: eventbridge-to-fanout
+          projectName: fastly-content-fanout
           configPath: cdk/cdk.out/riff-raff.yaml
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out
+            fastly-C@E-package:
+              - pkg/fastly-content-fanout.tar.gz

--- a/cdk/bin/__snapshots__/cdk.test.ts.snap
+++ b/cdk/bin/__snapshots__/cdk.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The riff-raff output YAML matches the snapshot 1`] = `
+"allowedStages:
+  - CODE
+  - PROD
+deployments:
+  cfn-eu-west-1-cms-fronts-eventbridge-to-fanout:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - cms-fronts
+    app: eventbridge-to-fanout
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        CODE: EventBridgeToFanout-eu-west-1-fronts-CODE.template.json
+        PROD: EventBridgeToFanout-eu-west-1-fronts-PROD.template.json
+  cfn-eu-west-1-content-api-fastly-cache-purger-eventbridge-to-fanout:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - content-api-fastly-cache-purger
+    app: eventbridge-to-fanout
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        CODE: EventBridgeToFanout-eu-west-1-capi-CODE.template.json
+        PROD: EventBridgeToFanout-eu-west-1-capi-PROD.template.json
+  fastly-C@E-package:
+    type: fastly-compute
+    app: fastly-content-fanout
+    contentDirectory: fastly-C@E-package
+    parameters: {}
+    regions:
+      - eu-west-1
+    stacks:
+      - mobile
+"
+`;

--- a/cdk/bin/cdk.test.ts
+++ b/cdk/bin/cdk.test.ts
@@ -1,0 +1,10 @@
+import {riffRaff} from "./cdk";
+
+describe('The riff-raff output YAML', () => {
+  it('matches the snapshot', () => {
+    // @ts-ignore
+    const outdir = riffRaff.outdir; // this changes for every test execution and best not to change cdk.ts too much
+    const riffRaffYaml = riffRaff.toYAML().replaceAll(outdir, 'cdk.out');
+    expect(riffRaffYaml).toMatchSnapshot();
+  });
+});

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -42,7 +42,7 @@ const env = { region: 'eu-west-1' };
 	});
 });
 
-const riffRaff = new RiffRaffYamlFile(app);
+export const riffRaff = new RiffRaffYamlFile(app);
 const { riffRaffYaml: { deployments } } = riffRaff;
 
 deployments.set("fastly-C@E-package", {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -32,7 +32,8 @@
   "prettier": "@guardian/prettier",
   "jest": {
     "testMatch": [
-      "<rootDir>/lib/**/*.test.ts"
+      "<rootDir>/lib/**/*.test.ts",
+      "<rootDir>/bin/**/*.test.ts"
     ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/fastly.toml
+++ b/fastly.toml
@@ -5,7 +5,7 @@ authors = ["tom.richards@guardian.co.uk", "david.lawes@guardian.co.uk"]
 description = "Compute@Edge app to update clients about new content"
 language = "javascript"
 manifest_version = 3
-name = "fastly-compute-fanout"
+name = "fastly-content-fanout"
 
 service_id = "SERVICE_ID"
 


### PR DESCRIPTION
Now #3 & #4 are merged, we can make use of https://github.com/guardian/cdk/pull/2042 to combine the `fastly-compute` deployment step with the auto-generated `cloud-formation` steps (for the EventBridge stacks) so we can have single riff-raff deployment `entitled `fastly-content-fanout` (matching the repo).