### PR TITLE
Use JSON as payload

### DIFF
--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -35,7 +35,7 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
                 "detail-path": "$.detail.path",
                 "time": "$.time",
               },
-              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"<time>\\n"}}}]}",
+              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"{\\"timestamp\\":\\"<time>\\"}\\n"}}}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -35,7 +35,7 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
                 "detail-path": "$.detail.path",
                 "time": "$.time",
               },
-              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":<time>},"http-stream":{"content":"<time>\\n"}}}]}",
+              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"<time>\\n"}}}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -58,7 +58,9 @@ export class EventbridgeToFanout extends GuStack {
 								formats: {
 									// websocket connections
 									'ws-message': {
-										content: events.EventField.fromPath('$.time'),
+										content: JSON.stringify({
+											timestamp: events.EventField.fromPath('$.time')
+										})
 									},
 									// sse connections
 									'http-stream': {

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -64,7 +64,9 @@ export class EventbridgeToFanout extends GuStack {
 									},
 									// sse connections
 									'http-stream': {
-										content: `${events.EventField.fromPath('$.time')}\n`,
+										content: `${JSON.stringify({
+											timestamp: events.EventField.fromPath('$.time')
+										})}\n`,
 									},
 								},
 							},

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -45,6 +45,9 @@ export class EventbridgeToFanout extends GuStack {
 			apiDestinationName: `fastly-fanout-api-destination-${this.stage}`,
 		});
 
+		const fanoutPayload: string = JSON.stringify({
+			timestamp: events.EventField.fromPath('$.time')
+		})
 		new events.Rule(this, 'ApiDestinationRule', {
 			eventBus: eventBridgeBus,
 			ruleName: `${this.stack}-events-to-fastly-fanout-${this.stage}`,
@@ -58,15 +61,11 @@ export class EventbridgeToFanout extends GuStack {
 								formats: {
 									// websocket connections
 									'ws-message': {
-										content: JSON.stringify({
-											timestamp: events.EventField.fromPath('$.time')
-										})
+										content: fanoutPayload,
 									},
 									// sse connections
 									'http-stream': {
-										content: `${JSON.stringify({
-											timestamp: events.EventField.fromPath('$.time')
-										})}\n`,
+										content: `${fanoutPayload}\n`,
 									},
 								},
 							},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
This addresses #11 

## What does this change?

This PR uses JSON formatted data as the payload.  Previously we use a timestamp as the payload body only.

The main purpose is to achieve better compatibility with old versions of clients.  As we extend the fanout and add additional fields to the payload over time, JSON formatted payload allows the client to handle new fields more gracefully.

## How to test

We deployed to CODE, made changes to the front and we were able to receive the expected JSON formatted payload via websocket and SSE channel.

