### PR TITLE
make SSE payload adhere to the standard

### DIFF
--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -35,7 +35,7 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
                 "detail-path": "$.detail.path",
                 "time": "$.time",
               },
-              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"{\\"timestamp\\":\\"<time>\\"}\\n"}}}]}",
+              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"data: {\\"timestamp\\":\\"<time>\\"}\\n\\n"}}}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -65,7 +65,7 @@ export class EventbridgeToFanout extends GuStack {
 									},
 									// sse connections
 									'http-stream': {
-										content: `${fanoutPayload}\n`,
+										content: `data: ${fanoutPayload}\n\n`,
 									},
 								},
 							},

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ async function handleRequest({ request }: FetchEvent) {
   }
 
   // assume this is server sent event
-  return new Response("welcome\n", { // TODO: can we send null for body?
+  return new Response(null, {
     status: 200,
     headers: {
       ...commonHeaders,


### PR DESCRIPTION
- Send double carriage return for SSE since `onmessage` of `EventSource` in the browser was not being fired 
- AND prefix each payload with `data: `
...as per https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format 

Plus remove the welcome message from SSE as it was unnecessary and not consistent with our web-socket implementation. 