### PR TITLE
expose collection IDs from SNS messages

### DIFF
--- a/cdk/bin/cdk.test.ts
+++ b/cdk/bin/cdk.test.ts
@@ -1,10 +1,10 @@
-import {riffRaff} from "./cdk";
+import { riffRaff } from './cdk';
 
 describe('The riff-raff output YAML', () => {
-  it('matches the snapshot', () => {
-    // @ts-ignore
-    const outdir = riffRaff.outdir; // this changes for every test execution and best not to change cdk.ts too much
-    const riffRaffYaml = riffRaff.toYAML().replaceAll(outdir, 'cdk.out');
-    expect(riffRaffYaml).toMatchSnapshot();
-  });
+	it('matches the snapshot', () => {
+		// @ts-ignore
+		const outdir = riffRaff.outdir; // this changes for every test execution and best not to change cdk.ts too much
+		const riffRaffYaml = riffRaff.toYAML().replaceAll(outdir, 'cdk.out');
+		expect(riffRaffYaml).toMatchSnapshot();
+	});
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -25,10 +25,10 @@ const env = { region: 'eu-west-1' };
 						pressType: ['live'], // only send live events
 					},
 				},
-				inputTemplate: {
-					path: '<$.body.path>',
-					collectionIds: '<$.body.collectionIds>'
-				},
+				inputTemplate: `{
+					"path": <$.body.path>,
+					"collectionIds": <$.body.collectionIds>
+				}`,
 			},
 		},
 	);
@@ -40,7 +40,7 @@ const env = { region: 'eu-west-1' };
 		env,
 		snsTopicUpdatesConfig: {
 			cfnExportName: 'fastly-cache-purger-PROD-DecachedContentSNSTopicARN', // there is only a PROD cache purger so using it for both CODE and PROD eventbridge
-			inputTemplate: {path: '<$.messageAttributes.path.stringValue>'},
+			inputTemplate: `{"path": <$.messageAttributes.path.stringValue>}`,
 		},
 	});
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -25,7 +25,10 @@ const env = { region: 'eu-west-1' };
 						pressType: ['live'], // only send live events
 					},
 				},
-				inputTemplatePath: '<$.body.path>',
+				inputTemplate: {
+					path: '<$.body.path>',
+					collectionIds: '<$.body.collectionIds>'
+				},
 			},
 		},
 	);
@@ -37,7 +40,7 @@ const env = { region: 'eu-west-1' };
 		env,
 		snsTopicUpdatesConfig: {
 			cfnExportName: 'fastly-cache-purger-PROD-DecachedContentSNSTopicARN', // there is only a PROD cache purger so using it for both CODE and PROD eventbridge
-			inputTemplatePath: '<$.messageAttributes.path.stringValue>',
+			inputTemplate: {path: '<$.messageAttributes.path.stringValue>'},
 		},
 	});
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -27,7 +27,7 @@ const env = { region: 'eu-west-1' };
 				},
 				inputTemplate: `{
 					"path": <$.body.path>,
-					"collectionIds": <$.body.collectionIds>
+					"fanoutPayload": <$.body.fanoutPayload>
 				}`,
 			},
 		},

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 import { EventbridgeToFanout } from '../lib/eventbridge-to-fanout';
-import {RiffRaffYamlFile} from "@guardian/cdk/lib/riff-raff-yaml-file";
-import {App} from "aws-cdk-lib";
+import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
+import { App } from 'aws-cdk-lib';
 
 const FRONTS_STACK = 'cms-fronts';
 const CAPI_STACK = 'content-api-fastly-cache-purger';
@@ -46,18 +46,19 @@ const env = { region: 'eu-west-1' };
 });
 
 export const riffRaff = new RiffRaffYamlFile(app);
-const { riffRaffYaml: { deployments } } = riffRaff;
+const {
+	riffRaffYaml: { deployments },
+} = riffRaff;
 
-deployments.set("fastly-C@E-package", {
-	type: "fastly-compute",
-	app: "fastly-content-fanout",
-	contentDirectory: "fastly-C@E-package",
+deployments.set('fastly-C@E-package', {
+	type: 'fastly-compute',
+	app: 'fastly-content-fanout',
+	contentDirectory: 'fastly-C@E-package',
 	parameters: {},
 	regions: new Set([env.region]),
-	stacks: new Set(["mobile"]),
+	stacks: new Set(['mobile']),
 });
 
 // Write the riff-raff.yaml file to the output directory.
 // Must be explicitly called.
 riffRaff.synth();
-

--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -250,7 +250,7 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
           ],
         },
         "TargetParameters": {
-          "InputTemplate": "{"path":"<$.foo.bar>"}",
+          "InputTemplate": "{"path": <$.foo.bar>}",
         },
       },
       "Type": "AWS::Pipes::Pipe",

--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -32,10 +32,11 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
             "Id": "Target0",
             "InputTransformer": {
               "InputPathsMap": {
+                "detail-collectionIds": "$.detail.collectionIds",
                 "detail-path": "$.detail.path",
                 "time": "$.time",
               },
-              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"data: {\\"timestamp\\":\\"<time>\\"}\\n\\n"}}}]}",
+              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\",\\"collectionIds\\":\\"<detail-collectionIds>\\"}"},"http-stream":{"content":"data: {\\"timestamp\\":\\"<time>\\",\\"collectionIds\\":\\"<detail-collectionIds>\\"}\\n\\n"}}}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -32,11 +32,10 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
             "Id": "Target0",
             "InputTransformer": {
               "InputPathsMap": {
-                "detail-collectionIds": "$.detail.collectionIds",
+                "detail-fanoutPayload": "$.detail.fanoutPayload",
                 "detail-path": "$.detail.path",
-                "time": "$.time",
               },
-              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\",\\"collectionIds\\":\\"<detail-collectionIds>\\"}"},"http-stream":{"content":"data: {\\"timestamp\\":\\"<time>\\",\\"collectionIds\\":\\"<detail-collectionIds>\\"}\\n\\n"}}}]}",
+              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":<detail-fanoutPayload>},"http-stream":{"content":"data: <detail-fanoutPayload>\\n\\n"}}}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
+++ b/cdk/lib/__snapshots__/eventbridge-to-fanout.test.ts.snap
@@ -32,10 +32,10 @@ exports[`The EventBridgeToFanout stack matches the snapshot 1`] = `
             "Id": "Target0",
             "InputTransformer": {
               "InputPathsMap": {
-                "detail-fanoutPayload": "$.detail.fanoutPayload",
                 "detail-path": "$.detail.path",
+                "time": "$.time",
               },
-              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":<detail-fanoutPayload>},"http-stream":{"content":"data: <detail-fanoutPayload>\\n\\n"}}}]}",
+              "InputTemplate": "{"items":[{"channel":<detail-path>,"formats":{"ws-message":{"content":"{\\"timestamp\\":\\"<time>\\"}"},"http-stream":{"content":"data: {\\"timestamp\\":\\"<time>\\"}\\n\\n"}}}]}",
             },
             "RoleArn": {
               "Fn::GetAtt": [

--- a/cdk/lib/eventbridge-to-fanout.test.ts
+++ b/cdk/lib/eventbridge-to-fanout.test.ts
@@ -10,7 +10,7 @@ describe('The EventBridgeToFanout stack', () => {
 			stage: 'TEST',
 			snsTopicUpdatesConfig: {
 				cfnExportName: 'test-sns-topic-export-name',
-				inputTemplate: {path: '<$.foo.bar>'},
+				inputTemplate: `{"path": <$.foo.bar>}`,
 				maybeFilterPattern: {
 					foo: {
 						bar: 'baz',

--- a/cdk/lib/eventbridge-to-fanout.test.ts
+++ b/cdk/lib/eventbridge-to-fanout.test.ts
@@ -10,7 +10,7 @@ describe('The EventBridgeToFanout stack', () => {
 			stage: 'TEST',
 			snsTopicUpdatesConfig: {
 				cfnExportName: 'test-sns-topic-export-name',
-				inputTemplatePath: '<$.foo.bar>',
+				inputTemplate: {path: '<$.foo.bar>'},
 				maybeFilterPattern: {
 					foo: {
 						bar: 'baz',

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -46,7 +46,8 @@ export class EventbridgeToFanout extends GuStack {
 		});
 
 		const fanoutPayload: string = JSON.stringify({
-			timestamp: events.EventField.fromPath('$.time')
+			timestamp: events.EventField.fromPath('$.time'),
+			collectionIds: events.EventField.fromPath('$.detail.collectionIds'), // only present on front update
 		})
 		new events.Rule(this, 'ApiDestinationRule', {
 			eventBus: eventBridgeBus,

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -14,7 +14,8 @@ interface EventbridgeToFanoutStackProps extends GuStackProps {
 	snsTopicUpdatesConfig: {
 		cfnExportName: string;
 		maybeFilterPattern?: object;
-		inputTemplate: {path: string} & Record<string, unknown>;
+		/* JSON-like template describing mapping from SNS events to event bridge event body.  Must include 'path' property */
+		inputTemplate: string;
 	};
 }
 
@@ -140,7 +141,7 @@ export class EventbridgeToFanout extends GuStack {
 			},
 			target: eventBridgeBus.eventBusArn,
 			targetParameters: {
-				inputTemplate: JSON.stringify(props.snsTopicUpdatesConfig.inputTemplate),
+				inputTemplate: props.snsTopicUpdatesConfig.inputTemplate.trim(),
 			},
 		});
 	}

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -14,7 +14,7 @@ interface EventbridgeToFanoutStackProps extends GuStackProps {
 	snsTopicUpdatesConfig: {
 		cfnExportName: string;
 		maybeFilterPattern?: object;
-		inputTemplatePath: string;
+		inputTemplate: {path: string} & Record<string, unknown>;
 	};
 }
 
@@ -140,9 +140,7 @@ export class EventbridgeToFanout extends GuStack {
 			},
 			target: eventBridgeBus.eventBusArn,
 			targetParameters: {
-				inputTemplate: JSON.stringify({
-					path: props.snsTopicUpdatesConfig.inputTemplatePath,
-				}),
+				inputTemplate: JSON.stringify(props.snsTopicUpdatesConfig.inputTemplate),
 			},
 		});
 	}

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -46,10 +46,7 @@ export class EventbridgeToFanout extends GuStack {
 			apiDestinationName: `fastly-fanout-api-destination-${this.stage}`,
 		});
 
-		const fanoutPayload: string = JSON.stringify({
-			timestamp: events.EventField.fromPath('$.time'),
-			collectionIds: events.EventField.fromPath('$.detail.collectionIds'), // only present on front update
-		})
+		const fanoutPayload: string = events.EventField.fromPath('$.detail.fanoutPayload')
 		new events.Rule(this, 'ApiDestinationRule', {
 			eventBus: eventBridgeBus,
 			ruleName: `${this.stack}-events-to-fastly-fanout-${this.stage}`,

--- a/cdk/lib/eventbridge-to-fanout.ts
+++ b/cdk/lib/eventbridge-to-fanout.ts
@@ -46,7 +46,11 @@ export class EventbridgeToFanout extends GuStack {
 			apiDestinationName: `fastly-fanout-api-destination-${this.stage}`,
 		});
 
-		const fanoutPayload: string = events.EventField.fromPath('$.detail.fanoutPayload')
+		const isFanoutPayloadInEvent =
+			props.snsTopicUpdatesConfig.inputTemplate.includes(`"fanoutPayload"`);
+		const fanoutPayload: string = isFanoutPayloadInEvent
+			? events.EventField.fromPath('$.detail.fanoutPayload')
+			: JSON.stringify({ timestamp: events.EventField.fromPath('$.time') });
 		new events.Rule(this, 'ApiDestinationRule', {
 			eventBus: eventBridgeBus,
 			ruleName: `${this.stack}-events-to-fastly-fanout-${this.stage}`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are working on adding more details about the changes made to a front to the payload of Fanout messages. 

We are going to raise a pull request (guardian/facia-tool#1599) on the fronts tool to add the ID of the modified collections in a front update event.

This pull request changes the input template of the eventbridge pipe for the collection IDs in SNS messages and returns them in the Fanout messages.